### PR TITLE
Fix pytest

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
 pip==19.0.3
 wheel==0.33.1
 twine==1.13.0
+Js2Py==0.70
 pytest


### PR DESCRIPTION
My test run failed due to a missing `js2py` dependency, so I added that and froze the dependencies.